### PR TITLE
Removed trailing space from default password

### DIFF
--- a/react-app/.env.development
+++ b/react-app/.env.development
@@ -1,4 +1,4 @@
 REACT_APP_HOST_URI=http://localhost:4502
 REACT_APP_GRAPHQL_ENDPOINT=/content/graphql/endpoint.gql
 # Uncomment the line below when connecting to an Author environment
-# REACT_APP_AUTHORIZATION=admin:admin 
+# REACT_APP_AUTHORIZATION=admin:admin


### PR DESCRIPTION
Removed trailing space from default password in ".env.development" file.