### PR TITLE
replaced node-sass with sass

### DIFF
--- a/react-app/package.json
+++ b/react-app/package.json
@@ -7,12 +7,12 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "http-proxy-middleware": "^1.0.6",
-    "node-sass": "^4.14.1",
     "normalize-scss": "^7.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "3.4.3"
+    "react-scripts": "3.4.3",
+    "sass": "^1.42.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
replace node-sass with dart sass. Brings the tutorial branch in line with the `main` branch

Fix for issue #42 

The most recent version of node that will be supported is v16.13.0 (Active LTS) and npm 8.1.0