### PR TITLE
React app useffect rename to be more semantic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ typings/
 
 # dotenv environment variables file
 .env
-.env.* 
 
 # next.js build output
 .next

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ typings/
 
 # dotenv environment variables file
 .env
+.env.* 
 
 # next.js build output
 .next
@@ -69,3 +70,4 @@ typings/
 
 # Mac OS
 .DS_Store
+

--- a/react-app/src/api/usePersistedQueries.js
+++ b/react-app/src/api/usePersistedQueries.js
@@ -57,11 +57,13 @@ async function fetchPersistedQuery(persistedQueryName, queryParameters) {
 }
 
 /**
+ * React custom hook that returns a list of adevntures by activity. If no activity is provided, all adventures are returned.
+ * 
  * Custom hook that calls the 'wknd-shared/adventures-all' or 'wknd-shared/adventures-by-activity' persisted query.
  *
  * @returns an array of Adventure JSON objects, and array of errors
  */
-export function useAllAdventures(adventureActivity) {
+export function useAdventuresByActivity(adventureActivity) {
 
   const [adventures, setAdventures] = useState(null);
   const [errors, setErrors] = useState(null);
@@ -74,15 +76,12 @@ export function useAllAdventures(adventureActivity) {
 
       // if an activity is set (i.e "Camping", "Hiking"...) call wknd-shared/adventures-by-activity query
       if (adventureActivity && adventureActivity !== '') {
-
         // The key is 'activity' as defined in the persisted query
         const queryParameters = { activity: adventureActivity };
 
         // Call the AEM GraphQL persisted query named "wknd-shared/adventures-by-activity" with parameters
         response = await fetchPersistedQuery("wknd-shared/adventures-by-activity", queryParameters);
-
       } else {
-
         // Call the AEM GraphQL persisted query named "wknd-shared/adventures-all"
         response = await fetchPersistedQuery("wknd-shared/adventures-all");
       }
@@ -144,7 +143,7 @@ export function useAdventureBySlug(slugName) {
     // Call the internal fetchData() as per React best practices
     fetchData();
 
-}, [slugName]);
+  }, [slugName]);
 
-return { adventure, references, errors };
+  return { adventure, references, errors };
 }

--- a/react-app/src/components/Adventures.js
+++ b/react-app/src/components/Adventures.js
@@ -6,20 +6,17 @@ NOTICE: Adobe permits you to use, modify, and distribute this file in
 accordance with the terms of the Adobe license agreement accompanying
 it.
 */
-
 import React from "react";
 import CurrencyFormat from 'react-currency-format';
 import { Link } from "react-router-dom";
-import { useAllAdventures } from "../api/usePersistedQueries";
-import './Adventures.scss';
+import { useAdventuresByActivity } from "../api/usePersistedQueries";
 import Error from "./Error";
 import Loading from "./Loading";
-
-
+import './Adventures.scss';
 
 function Adventures({ adventureActivity }) {
 
-    const { adventures, error } = useAllAdventures(adventureActivity);
+    const { adventures, error } = useAdventuresByActivity(adventureActivity);
 
     // Handle error and loading conditions
     if (error) {
@@ -29,7 +26,6 @@ function Adventures({ adventureActivity }) {
     }
 
     return (
-
         <div className="adventures">
             <ul className="adventure-items">
                 {adventures.map((adventure, index) => {
@@ -39,16 +35,15 @@ function Adventures({ adventureActivity }) {
         </div>
 
     );
-
 }
 
 // Render individual Adventure item
 function AdventureListItem({ title, slug, primaryImage, tripLength, price }) {
-
-    //Must have title, path, and image
+    // Must have title, path, and image
     if (!title || !title || !primaryImage) {
         return null;
     }
+
     return (
         <li className="adventure-item">
             <Link to={`/adventure/${slug}`}>


### PR DESCRIPTION
Change the useEffect hook name from `useAllAdventures` to `useAdventuresByActivity` as this is what it really does (albeit you can not provide any activity as well, and it will return "all" adventures)

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
