### PR TITLE
Parameterized graphql endpoint and caching

### DIFF
--- a/react-app/.env.development
+++ b/react-app/.env.development
@@ -6,9 +6,9 @@ REACT_APP_HOST_URI=https://publish-p123-e456.adobeaemcloud.com/
 # Graphql endpoint namespace
 REACT_APP_GRAPHQL_ENDPOINT=wknd-shared
 
-# CACHE and TTL can be configured as PersistedQuery header in AEM
-# The ability to disable CACHING is only for demo purposes
-ENABLE_CACHE=false
+# The ability to disable CACHING is ONLY for demo purposes. You should NEVER disable caching in production. Setting this to true will ad cache-busting parameters.
+# Production-use CACHE and TTL can be configured as PersistedQuery header in AEM
+DISABLE_CACHE=false
 
 # Dev modes, use proxy during development (helps avoids potential CORS issues)
 REACT_APP_USE_PROXY=true

--- a/react-app/.env.development
+++ b/react-app/.env.development
@@ -4,7 +4,7 @@
 REACT_APP_HOST_URI=https://publish-p123-e456.adobeaemcloud.com/
 
 # Graphql endpoint namespace
-REACT_APP_GRAPHQL_ENDPOINT=aem-demo-assets
+REACT_APP_GRAPHQL_ENDPOINT=wknd-shared
 
 # CACHE and TTL can be configured as PersistedQuery header in AEM
 # The ability to disable CACHING is only for demo purposes

--- a/react-app/.env.development
+++ b/react-app/.env.development
@@ -6,7 +6,7 @@ REACT_APP_HOST_URI=https://publish-p123-e456.adobeaemcloud.com/
 # Graphql endpoint namespace
 REACT_APP_GRAPHQL_ENDPOINT=wknd-shared
 
-# The ability to disable CACHING is ONLY for demo purposes. You should NEVER disable caching in production. Setting this to true will ad cache-busting parameters.
+# The ability to disable CACHING is ONLY for demo purposes. You should NEVER disable caching in production. Setting this to true will add cache-busting parameters to the AEM Headless API request.
 # Production-use CACHE and TTL can be configured as PersistedQuery header in AEM
 DISABLE_CACHE=false
 

--- a/react-app/.env.development
+++ b/react-app/.env.development
@@ -3,6 +3,13 @@
 # Server namespace
 REACT_APP_HOST_URI=https://publish-p123-e456.adobeaemcloud.com/
 
+# Graphql endpoint namespace
+REACT_APP_GRAPHQL_ENDPOINT=aem-demo-assets
+
+# CACHE and TTL can be configured as PersistedQuery header in AEM
+# The ability to disable CACHING is only for demo purposes
+ENABLE_CACHE=false
+
 # Dev modes, use proxy during development (helps avoids potential CORS issues)
 REACT_APP_USE_PROXY=true
 

--- a/react-app/src/api/aemHeadlessClient.js
+++ b/react-app/src/api/aemHeadlessClient.js
@@ -13,7 +13,6 @@ import AEMHeadless from "@adobe/aem-headless-client-js";
 // environment variable for configuring the headless client
 const {
   REACT_APP_HOST_URI,
-  REACT_APP_GRAPHQL_ENDPOINT,
   REACT_APP_USE_PROXY,
   REACT_APP_AUTH_METHOD,
   REACT_APP_DEV_TOKEN,
@@ -42,7 +41,6 @@ const setAuthorization = () => {
 // Initialize the AEM Headless Client and export it for other files to use
 const aemHeadlessClient = new AEMHeadless({
   serviceURL: serviceURL,
-  endpoint: REACT_APP_GRAPHQL_ENDPOINT,
   auth: setAuthorization(),
 });
 

--- a/react-app/src/api/usePersistedQueries.js
+++ b/react-app/src/api/usePersistedQueries.js
@@ -66,7 +66,7 @@ async function fetchPersistedQuery(persistedQueryName, queryParameters) {
 /**
  * React custom hook that returns a list of adventures by activity. If no activity is provided, all adventures are returned.
  * 
- * Custom hook that calls the '[graphql endpoint namspace]/adventures-all' or '[graphql endpoint namspace]/adventures-by-activity' persisted query.
+ * Custom hook that calls the '[graphql endpoint namespace]/adventures-all' or '[graphql endpoint namespace]/adventures-by-activity' persisted query.
  *
  * @returns an array of Adventure JSON objects, and array of errors
  */

--- a/react-app/src/api/usePersistedQueries.js
+++ b/react-app/src/api/usePersistedQueries.js
@@ -130,7 +130,7 @@ export function useAdventureBySlug(slugName, params) {
         slug: slugName,
       };
 
-      // Call the AEM GraphQL persisted query named "[graphql endpoint namspace]/adventure-by-slug" with parameters
+      // Call the AEM GraphQL persisted query named "[graphql endpoint namespace]/adventure-by-slug" with parameters
       response = await fetchPersistedQuery(
         REACT_APP_GRAPHQL_ENDPOINT + "/adventure-by-slug",
         queryVariables

--- a/react-app/src/api/usePersistedQueries.js
+++ b/react-app/src/api/usePersistedQueries.js
@@ -109,7 +109,7 @@ export function useAdventuresByActivity(adventureActivity, params) {
 }
 
 /**
- * Calls the '[graphql endpoint namspace]/adventure-by-slug' persisted query with `slug` parameter.
+ * Calls the '[graphql endpoint namespace]/adventure-by-slug' persisted query with `slug` parameter.
  *
  * @param {String!} slugName the adventure slug
  * @returns a JSON object representing the Adventure

--- a/react-app/src/api/usePersistedQueries.js
+++ b/react-app/src/api/usePersistedQueries.js
@@ -35,7 +35,8 @@ async function fetchPersistedQuery(persistedQueryName, queryParameters) {
   let data;
   let err;
 
-  if (ENABLE_CACHE === "false") {
+  // Do NOT disable cache in production. This toggle is this demo app is only to help you quickly explore AEM's Headless APIs without having to wait for cache expiration to see changes.
+  if (DISABLE_CACHE === "true") {
     if (queryParameters === "undefined") {
       queryParameters = {};
     }

--- a/react-app/src/api/usePersistedQueries.js
+++ b/react-app/src/api/usePersistedQueries.js
@@ -81,7 +81,7 @@ export function useAdventuresByActivity(adventureActivity, params) {
       let queryVariables = params;
       let response;
 
-      // if an activity is set (i.e "Camping", "Hiking"...) call [graphql endpoint namspace]/adventures-by-activity query
+      // if an activity is set (i.e "Camping", "Hiking"...) call [graphql endpoint namespace]/adventures-by-activity query
       if (adventureActivity) {
         // The key is 'activity' as defined in the persisted query
         queryVariables = { ...queryVariables, activity: adventureActivity };

--- a/react-app/src/api/usePersistedQueries.js
+++ b/react-app/src/api/usePersistedQueries.js
@@ -89,7 +89,7 @@ export function useAdventuresByActivity(adventureActivity, params) {
         // Call the AEM GraphQL persisted query named "[graphql endpoint namespace]/adventures-by-activity" with parameters
         response = await fetchPersistedQuery(REACT_APP_GRAPHQL_ENDPOINT + "/adventures-by-activity", queryVariables);
       } else {
-        // Call the AEM GraphQL persisted query named "[graphql endpoint namspace]/adventures-all"
+        // Call the AEM GraphQL persisted query named "[graphql endpoint namespace]/adventures-all"
         response = await fetchPersistedQuery(REACT_APP_GRAPHQL_ENDPOINT + "/adventures-all", queryVariables);
       }
 

--- a/react-app/src/api/usePersistedQueries.js
+++ b/react-app/src/api/usePersistedQueries.js
@@ -11,7 +11,7 @@ import { useEffect, useState } from "react";
 import aemHeadlessClient from "./aemHeadlessClient";
 
 // environment variable for configuring the headless client
-const { ENABLE_CACHE, REACT_APP_GRAPHQL_ENDPOINT} = process.env;
+const { DISABLE_CACHE, REACT_APP_GRAPHQL_ENDPOINT} = process.env;
 
 /**
  * This file contains the React useEffect custom hooks that:

--- a/react-app/src/api/usePersistedQueries.js
+++ b/react-app/src/api/usePersistedQueries.js
@@ -86,7 +86,7 @@ export function useAdventuresByActivity(adventureActivity, params) {
         // The key is 'activity' as defined in the persisted query
         queryVariables = { ...queryVariables, activity: adventureActivity };
 
-        // Call the AEM GraphQL persisted query named "[graphql endpoint namspace]/adventures-by-activity" with parameters
+        // Call the AEM GraphQL persisted query named "[graphql endpoint namespace]/adventures-by-activity" with parameters
         response = await fetchPersistedQuery(REACT_APP_GRAPHQL_ENDPOINT + "/adventures-by-activity", queryVariables);
       } else {
         // Call the AEM GraphQL persisted query named "[graphql endpoint namspace]/adventures-all"

--- a/react-app/src/api/usePersistedQueries.js
+++ b/react-app/src/api/usePersistedQueries.js
@@ -10,6 +10,9 @@ it.
 import { useEffect, useState } from "react";
 import aemHeadlessClient from "./aemHeadlessClient";
 
+// environment variable for configuring the headless client
+const { ENABLE_CACHE, REACT_APP_GRAPHQL_ENDPOINT} = process.env;
+
 /**
  * This file contains the React useEffect custom hooks that:
  * 1. Are called by the React components
@@ -31,6 +34,13 @@ import aemHeadlessClient from "./aemHeadlessClient";
 async function fetchPersistedQuery(persistedQueryName, queryParameters) {
   let data;
   let err;
+
+  if (ENABLE_CACHE === "false") {
+    if (queryParameters === "undefined") {
+      queryParameters = {};
+    }
+    queryParameters.timestamp = new Date().getTime();
+  }
 
   try {
     // AEM GraphQL queries are asynchronous, either await their return or use Promise-based .then(..) { ... } syntax
@@ -55,7 +65,7 @@ async function fetchPersistedQuery(persistedQueryName, queryParameters) {
 /**
  * React custom hook that returns a list of adventures by activity. If no activity is provided, all adventures are returned.
  * 
- * Custom hook that calls the 'wknd-shared/adventures-all' or 'wknd-shared/adventures-by-activity' persisted query.
+ * Custom hook that calls the '[graphql endpoint namspace]/adventures-all' or '[graphql endpoint namspace]/adventures-by-activity' persisted query.
  *
  * @returns an array of Adventure JSON objects, and array of errors
  */
@@ -70,16 +80,16 @@ export function useAdventuresByActivity(adventureActivity, params) {
       let queryVariables = params;
       let response;
 
-      // if an activity is set (i.e "Camping", "Hiking"...) call wknd-shared/adventures-by-activity query
+      // if an activity is set (i.e "Camping", "Hiking"...) call [graphql endpoint namspace]/adventures-by-activity query
       if (adventureActivity) {
         // The key is 'activity' as defined in the persisted query
         queryVariables = { ...queryVariables, activity: adventureActivity };
 
-        // Call the AEM GraphQL persisted query named "wknd-shared/adventures-by-activity" with parameters
-        response = await fetchPersistedQuery("wknd-shared/adventures-by-activity", queryVariables);
+        // Call the AEM GraphQL persisted query named "[graphql endpoint namspace]/adventures-by-activity" with parameters
+        response = await fetchPersistedQuery(REACT_APP_GRAPHQL_ENDPOINT + "/adventures-by-activity", queryVariables);
       } else {
-        // Call the AEM GraphQL persisted query named "wknd-shared/adventures-all"
-        response = await fetchPersistedQuery("wknd-shared/adventures-all", queryVariables);
+        // Call the AEM GraphQL persisted query named "[graphql endpoint namspace]/adventures-all"
+        response = await fetchPersistedQuery(REACT_APP_GRAPHQL_ENDPOINT + "/adventures-all", queryVariables);
       }
 
       // Sets the adventures variable to the list of adventure JSON objects
@@ -98,7 +108,7 @@ export function useAdventuresByActivity(adventureActivity, params) {
 }
 
 /**
- * Calls the 'wknd-shared/adventure-by-slug' persisted query with `slug` parameter.
+ * Calls the '[graphql endpoint namspace]/adventure-by-slug' persisted query with `slug` parameter.
  *
  * @param {String!} slugName the adventure slug
  * @returns a JSON object representing the Adventure
@@ -119,9 +129,9 @@ export function useAdventureBySlug(slugName, params) {
         slug: slugName,
       };
 
-      // Call the AEM GraphQL persisted query named "wknd-shared/adventure-by-slug" with parameters
+      // Call the AEM GraphQL persisted query named "[graphql endpoint namspace]/adventure-by-slug" with parameters
       response = await fetchPersistedQuery(
-        "wknd-shared/adventure-by-slug",
+        REACT_APP_GRAPHQL_ENDPOINT + "/adventure-by-slug",
         queryVariables
       );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Instead of hardcoding it in usePersistedQueries.js, graphql endpoint namespace is now part of .env.
Graphql caching can be configured in .env.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/aem-guides-wknd-graphql/issues/95

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Both customers with AEM Guides WKND installed and Adobe internal with Reference Demo installed can use the code hosted on code sandbox, simply change the graphql endpoint namespace to enable the sample hosted app to pull content from their environment.
https://experienceleague.adobe.com/landing/experience-manager/headless/developer/code/basic-react-app.html?lang=en

## How Has This Been Tested?
tested locally and tested on online hosted sandbox
https://codesandbox.io/p/sandbox/wknd-react-app-forked-gfrtlf

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
